### PR TITLE
Revert "Revert "Change in tests "Altom" name in imports for C# package""

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This project contains C# AltTester tests for a project using the New Input Syste
 The tested actions are: move mouse, click, begin/move/end touch, swipe, key down/key up, press key, tilt, scroll .
 
 ## Before running the tests
-To run the tests, you must include the AltTester Unity SDK in the project. To do that, you can choose between the following ways:
+❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running.
+
+- Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+- To run the tests, you must include the AltTester Unity SDK in the project. To do that, you can choose between the following ways:
 1. Add the AltTester Unity SDK submodule to the project
     - use ``git submodule update --init`` command to pull the git submodule;
     - make sure that the submodule added is on the master branch (you can use the following command ``git checkout master`` in the <i>Assets/AltTester-Unity-SDK</i> folder);

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The tested actions are: move mouse, click, begin/move/end touch, swipe, key down
 ## Before running the tests
 ❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running.
 
-- Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+- Install the [AltTesterDesktop](https://alttester.com/alttester/#pricing), then open it.
 - To run the tests, you must include the AltTester Unity SDK in the project. To do that, you can choose between the following ways:
 1. Add the AltTester Unity SDK submodule to the project
     - use ``git submodule update --init`` command to pull the git submodule;

--- a/RollABall/Assets/Editor/Tests/Tests_AltTester.cs
+++ b/RollABall/Assets/Editor/Tests/Tests_AltTester.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading;
-using Altom.AltDriver;
+using AltTester.AltDriver;
 using NUnit.Framework;
 using UnityEngine;
 

--- a/RollABall/Assets/Editor/Tests/Tests_AltTester.cs
+++ b/RollABall/Assets/Editor/Tests/Tests_AltTester.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 using NUnit.Framework;
 using UnityEngine;
 


### PR DESCRIPTION
Reverts alttester/EXAMPLES-NewInputSystem--RollABall-CSharp#9
In this PR will be done:

- Change in tests "Altom" name in imports for C# package
- Update the readme.md

the PR for this issue should be merged on the main branch only when we have the released tester for pro 1.0